### PR TITLE
fix: Made the pr agent only work on develop

### DIFF
--- a/.github/workflows/pr_agent_approve.yml
+++ b/.github/workflows/pr_agent_approve.yml
@@ -3,10 +3,9 @@ name: PR Agent Approval
 on:
   pull_request_review:
     types: [submitted]
-
 jobs:
   auto_approve:
-    if: github.event.review.state == 'approved' && github.event.review.user.login == 'codiumai-pr-agent-free[bot]'
+    if: github.event.pull_request.base.ref == 'develop' && github.event.review.state == 'approved' && github.event.review.user.login == 'codiumai-pr-agent-free[bot]'
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
### **Description**
- Updated the GitHub Actions workflow to ensure the PR agent only approves pull requests targeting the 'develop' branch.
- Modified the `if` condition in the `auto_approve` job to include a check for the base branch.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_agent_approve.yml</strong><dd><code>Restrict PR Agent Approval to Develop Branch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr_agent_approve.yml

<li>Added condition to check if the base branch is 'develop'.<br> <li> Modified the <code>if</code> condition for the <code>auto_approve</code> job.<br>


</details>


  </td>
  <td><a href="https://github.com/EGC-Gazpacho/gazpacho-hub/pull/36/files#diff-9274f11d6cafde19c99ff1b3e503f44d8b03ef39e1b815e67e8584f31a9d89a4">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information