### PR TITLE
feat: Added functionality to download dataset from frontend

### DIFF
--- a/app/modules/dataset/templates/dataset/view_dataset.html
+++ b/app/modules/dataset/templates/dataset/view_dataset.html
@@ -330,17 +330,18 @@
             <i data-feather="download" class="center-button-icon"></i>
             Download all ({{ dataset.get_file_total_size_for_human() }})
         </a>
-        <a  class="btn btn-primary mt-3" style="border-radius: 5px;">
+        <a href="/dataset/download_informat/xml/{{ dataset.id }}" class="btn btn-primary mt-3" style="border-radius: 5px;">
             <i data-feather="download" class="center-button-icon"></i>
             Download in .xml
         </a>
-        <a class="btn btn-primary mt-3" style="border-radius: 5px;">
+        <a href="/dataset/download_informat/json/{{ dataset.id }}" class="btn btn-primary mt-3" style="border-radius: 5px;">
             <i data-feather="download" class="center-button-icon"></i>
             Download in .json
         </a>
-        <a class="btn btn-primary mt-3" style="border-radius: 5px;">
+        <a href="/dataset/download_informat/yaml/{{ dataset.id }}" class="btn btn-primary mt-3" style="border-radius: 5px;">
             <i data-feather="download" class="center-button-icon"></i>
             Download in .yaml
+        </a>
         </a>
     </div>
     


### PR DESCRIPTION
### **User description**
Added the logic in front in order to be capable to download the data from de dataset.


___

### **Description**
- Added functionality to download datasets in multiple formats (XML, JSON, YAML) from the frontend.
- Updated the HTML template to include new download links with appropriate routes.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>view_dataset.html</strong><dd><code>Add dataset download options in multiple formats</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/modules/dataset/templates/dataset/view_dataset.html

<li>Added download links for dataset in XML, JSON, and YAML formats.<br> <li> Updated HTML anchor tags with appropriate href attributes for new <br>formats.<br>


</details>


  </td>
  <td><a href="https://github.com/EGC-Gazpacho/gazpacho-hub/pull/52/files#diff-ce7eeb31c7f0422819b9bbf4a2d11f7499405f7041b912b184c840fe09a14ac7">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information