### PR TITLE
Feature/64 commits hook

### DIFF
--- a/.github/workflows/commit-validator.yml
+++ b/.github/workflows/commit-validator.yml
@@ -3,7 +3,7 @@ name: Validate Commit Messages
 on:
   push:
     branches:
-      - '**'  # Ejecutar en todas las ramas
+      - '**'  
 
 jobs:
   validate-commits:

--- a/.github/workflows/commit-validator.yml
+++ b/.github/workflows/commit-validator.yml
@@ -3,7 +3,7 @@ name: Validate Commit Messages
 on:
   push:
     branches:
-      - '**'  
+      - '**'  # Ejecutar en todas las ramas
 
 jobs:
   validate-commits:

--- a/.github/workflows/commit-validator.yml
+++ b/.github/workflows/commit-validator.yml
@@ -1,0 +1,33 @@
+name: Validate Commit Messages
+
+on:
+  push:
+    branches:
+      - '**'  
+
+jobs:
+  validate-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Validate Commit Messages
+        run: |
+          # Recorre los commits del push actual
+          git log --oneline FETCH_HEAD | while read -r commit; do
+            # Extrae el mensaje ignorando el hash
+            message=$(echo "$commit" | sed 's/^[a-f0-9]* //')
+            
+            # Excluir commit de fusión
+            if [[ "$message" =~ ^Merge ]]; then
+              continue  # Saltar la validación si es un commit de fusión
+            fi
+
+            # Validar el mensaje
+            if [[ ! "$message" =~ ^(feat:|fix:|doc:)[[:space:]]+[A-Z] ]]; then
+              echo "❌ Invalid commit message: $message"
+              echo "Expected format: feat/fix/doc: \"Message\", where Message starts with an uppercase letter."
+              exit 1
+            fi
+          done


### PR DESCRIPTION
### **User description**
Added webhook for commit message policy

-------
###  **Description**

- Introduces a webhook designed to enforce the commit message policy in the project repository. 
- It checks that messages follow the defined structure feat:, fix:, doc:, followed by a message starting with an uppercase letter,  rejecting commits that do not meet these criteria.


___

### **Description**
- Introduced a GitHub Actions workflow to enforce a standardized commit message policy.
- The workflow triggers on all branch pushes and validates commit messages.
- Commit messages must start with `feat:`, `fix:`, or `doc:` followed by a message starting with an uppercase letter.
- Invalid commit messages result in a failed check with an error message.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>commit-validator.yml</strong><dd><code>Add GitHub Actions workflow for commit message validation</code></dd></summary>
<hr>

.github/workflows/commit-validator.yml

<li>Added a GitHub Actions workflow to validate commit messages.<br> <li> Configured the workflow to trigger on all branch pushes.<br> <li> Implemented a script to enforce commit message format.<br> <li> Provided error messages for invalid commit messages.<br>


</details>


  </td>
  <td><a href="https://github.com/EGC-Gazpacho/gazpacho-hub/pull/65/files#diff-11af35a5b8465f0891610d6bb193d69133879ce2a36ffb79da79f4c897d31fb0">+33/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information