### PR TITLE
fix: Github token in CI/CD workflows

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -51,3 +51,4 @@ jobs:
         MARIADB_USER: uvlhub_user
         MARIADB_PASSWORD: uvlhub_password
         CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.UPLOAD_TOKEN_GITHUB }}

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -46,6 +46,7 @@ jobs:
         MARIADB_TEST_DATABASE: uvlhubdb_test
         MARIADB_USER: uvlhub_user
         MARIADB_PASSWORD: uvlhub_password
+        GITHUB_TOKEN: ${{ secrets.UPLOAD_TOKEN_GITHUB }}
       run: |
         pytest app/modules/ --ignore-glob='*selenium*'
 


### PR DESCRIPTION
### **Description**
- Added `GITHUB_TOKEN` environment variable to both Codacy and Render GitHub workflows.
- The token is sourced from `secrets.UPLOAD_TOKEN_GITHUB`.
- This change aims to fix issues related to GitHub token usage in CI/CD workflows.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>codacy.yml</strong><dd><code>Add GITHUB_TOKEN to Codacy workflow environment variables</code></dd></summary>
<hr>

.github/workflows/codacy.yml

<li>Added <code>GITHUB_TOKEN</code> environment variable.<br> <li> Utilizes <code>secrets.UPLOAD_TOKEN_GITHUB</code> for the token.<br>


</details>


  </td>
  <td><a href="https://github.com/EGC-Gazpacho/gazpacho-hub/pull/98/files#diff-f0d3530b5eea10fe26ad541e683cfb4072e290804705de6abf6a5b2e80a72f59">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>render.yml</strong><dd><code>Add GITHUB_TOKEN to Render workflow environment variables</code></dd></summary>
<hr>

.github/workflows/render.yml

<li>Added <code>GITHUB_TOKEN</code> environment variable.<br> <li> Utilizes <code>secrets.UPLOAD_TOKEN_GITHUB</code> for the token.<br>


</details>


  </td>
  <td><a href="https://github.com/EGC-Gazpacho/gazpacho-hub/pull/98/files#diff-e8d2905cf978c32afedd3e21246fab0ea16889a8641be60e05899991460fffb3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information