### PR TITLE
Implement ignore of the test_integration of github module

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Upload coverage to Codacy
       run: |
         pip install codacy-coverage
-        coverage run -m pytest app/modules/ --ignore-glob='*selenium*'
+        coverage run -m pytest app/modules/ --ignore-glob='*selenium*' --ignore-glob='*selenium*' --ignore-glob='app/modules/github/tests/test_integration.py'
         coverage xml 
         python-codacy-coverage -r coverage.xml
       env:


### PR DESCRIPTION
### **User description**
-Added ignore-glob to ignore the integration tests of github module in the codacy workflow


___

### **Description**
- Modified Codacy workflow to exclude GitHub integration tests from coverage reporting
- Added `--ignore-glob='app/modules/github/tests/test_integration.py'` to pytest command
- Prevents rate limit issues with GitHub API during CI/CD pipeline



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>codacy.yml</strong><dd><code>Update test coverage configuration to exclude GitHub integration tests</code></dd></summary>
<hr>

.github/workflows/codacy.yml

<li>Added ignore pattern for github module integration tests in pytest <br>command<br> <li> Modified coverage run command to exclude test_integration.py from <br>github module<br>


</details>


  </td>
  <td><a href="https://github.com/EGC-Gazpacho/gazpacho-hub/pull/131/files#diff-f0d3530b5eea10fe26ad541e683cfb4072e290804705de6abf6a5b2e80a72f59">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information