### PR TITLE
fix: Removed redundant testing from deployment workflow

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -1,58 +1,15 @@
 name: Deploy to Render
 
 on:
-    pull_request:
-      types: [closed]
-      branches:
-        - main
+  pull_request:
+    types: [closed]
+    branches:
+      - main
 
 jobs:
 
-  testing:
-
-    name: Run Tests
-    runs-on: ubuntu-latest
-
-    services:
-      mysql:
-        image: mysql:5.7
-        env:
-          MYSQL_ROOT_PASSWORD: uvlhub_root_password
-          MYSQL_DATABASE: uvlhubdb_test
-          MYSQL_USER: uvlhub_user
-          MYSQL_PASSWORD: uvlhub_password
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-
-    steps:
-
-    - uses: actions/checkout@v4
-
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.12'
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-
-    - name: Run Tests
-      env:
-        FLASK_ENV: testing
-        MARIADB_HOSTNAME: 127.0.0.1
-        MARIADB_PORT: 3306
-        MARIADB_TEST_DATABASE: uvlhubdb_test
-        MARIADB_USER: uvlhub_user
-        MARIADB_PASSWORD: uvlhub_password
-        GITHUB_TOKEN: ${{ secrets.UPLOAD_TOKEN_GITHUB }}
-      run: |
-        pytest app/modules/ --ignore-glob='*selenium*'
-
   deploy:
     name: Deploy to Render
-    needs: testing
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
@@ -66,7 +23,7 @@ jobs:
 
   verify-deployment:
     runs-on: ubuntu-latest
-    needs: deploy 
+    needs: deploy
     steps:
       - name: Wait for deployment to be ready
         run: sleep 300


### PR DESCRIPTION
### **Description**
- Streamlined the deployment workflow by removing redundant testing job that was running after PR merge
- Testing is already performed during PR checks, making post-merge testing unnecessary
- Deployment now triggers immediately after PR merge
- Fixed minor formatting and indentation issues in the workflow file



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>render.yml</strong><dd><code>Remove testing step from deployment workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/render.yml

<li>Removed redundant testing job from deployment workflow<br> <li> Fixed indentation in workflow trigger section<br> <li> Minor formatting fixes<br>


</details>


  </td>
  <td><a href="https://github.com/EGC-Gazpacho/gazpacho-hub/pull/138/files#diff-e8d2905cf978c32afedd3e21246fab0ea16889a8641be60e05899991460fffb3">+6/-49</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information