### PR TITLE
Develop

### DIFF
--- a/docker/entrypoints/render_entrypoint.sh
+++ b/docker/entrypoints/render_entrypoint.sh
@@ -51,6 +51,16 @@ else
     flask db upgrade
 fi
 
+# Check if any user exists in the database
+USER_EXISTS=$(flask shell -c "from app.models import User; print(bool(User.query.first()))" 2>/dev/null)
+
+if [ "$USER_EXISTS" = "False" ]; then
+  echo "No users found in the database. Running seed command..."
+  rosemary db:seed
+else
+  echo "Users already exist. Skipping seed command."
+fi
+
 # Start the application using Gunicorn, binding it to port 80
 # Set the logging level to info and the timeout to 3600 seconds
 exec gunicorn --bind 0.0.0.0:80 app:app --log-level info --timeout 3600


### PR DESCRIPTION
### **Description**
- Added automatic database seeding functionality to the render entrypoint script
- Checks if any users exist in the database before running seed command
- Prevents duplicate seeding by only running when database is empty
- Improves deployment automation and initial setup process



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>render_entrypoint.sh</strong><dd><code>Add automatic database seeding on deployment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker/entrypoints/render_entrypoint.sh

<li>Added database seeding check to populate initial user data if database <br>is empty<br> <li> Executes <code>rosemary db:seed</code> command if no users exist<br> <li> Added error handling to prevent duplicate seeding<br>


</details>


  </td>
  <td><a href="https://github.com/EGC-Gazpacho/gazpacho-hub/pull/145/files#diff-8862e4558dfbd50da8599851dd36e3ebbdf231d4ba4f918e57d01db5605e6567">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information